### PR TITLE
cAdvisor docker error

### DIFF
--- a/webapp/docker-compose.yml
+++ b/webapp/docker-compose.yml
@@ -21,7 +21,6 @@ services:
     - /:/rootfs:ro
     - /var/run:/var/run:rw
     - /sys:/sys:ro
-    - /var/lib/docker/:/var/lib/docker:ro
     - /dev/disk/:/dev/disk:ro
   grafana:
     image: grafana/grafana:latest


### PR DESCRIPTION
Resolve error running cAdvisor docker package on Ubuntu 22.04.1 LTS.